### PR TITLE
Disabling FrozenLiteralComment

### DIFF
--- a/rubocul_default.yml
+++ b/rubocul_default.yml
@@ -1,2 +1,5 @@
 inherit_gem:
   bixby: bixby_default.yml
+
+Style/FrozenStringLiteralComment:
+  Enabled: false


### PR DESCRIPTION
Eric and I would recommend that we turn this cop off and deal with literal string being frozen by default once ruby 3.0 is released and we start migrating our apps over to the new version of ruby. We are unsure if this is the right answer so we would definitely welcome more opinions!

Please 👍/👎.