### PR TITLE
Allowing braces for multiline blocks when chaining

### DIFF
--- a/rubocul_default.yml
+++ b/rubocul_default.yml
@@ -1,2 +1,5 @@
 inherit_gem:
   bixby: bixby_default.yml
+
+Style/BlockDelimiters:
+  EnforcedStyle: braces_for_chaining


### PR DESCRIPTION
I propose that instead of always requiring multiline blocks to be delineated with a `do...end`, we allow multiline blocks to be delineated with `{}` when they are being chained.

For example when testing exceptions:
This,
```
      expect {
        usage_stats.item(doi).get_stat(Statistic::VIEW, 'May 2017')
      }.to raise_error 'View May 2017 not part of stats. Check parameters.'
```

is a lot more readable than this,
```
      expect do
        usage_stats.item(doi).get_stat(Statistic::VIEW, 'May 2017')
      end.to raise_error 'View May 2017 not part of stats. Check parameters.'
```