### PR TITLE
Disabling AlignHash

### DIFF
--- a/rubocul_default.yml
+++ b/rubocul_default.yml
@@ -1,2 +1,6 @@
 inherit_gem:
   bixby: bixby_default.yml
+
+# Turning off until we can support multiple enforced styles (key and table). This is available in newer version of rubocop
+Layout/AlignHash:
+  Enabled: false


### PR DESCRIPTION
Newer version of rubocop allow us to configure two styles, which would better support our team. Turning off for now.

Please 👍/👎.