### PR TITLE
Added Layout/IndentHash rule with EnforcedStyle=consistent

### DIFF
--- a/rubocul_default.yml
+++ b/rubocul_default.yml
@@ -5,5 +5,8 @@ inherit_gem:
 Layout/AlignHash:
   Enabled: false
 
+Layout/IndentHash:
+  EnforcedStyle: consistent
+
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining

--- a/rubocul_default.yml
+++ b/rubocul_default.yml
@@ -1,10 +1,11 @@
 inherit_gem:
   bixby: bixby_default.yml
 
-# Turning off until we can support multiple enforced styles (key and table). This is available in newer version of rubocop
+# Turning off until we can support multiple enforced styles (key and table). This is available in newer version of rubocop.
 Layout/AlignHash:
   Enabled: false
 
+# In Rubocop 0.68 (a newer version than we're using right now), the IndentHash rule has been renamed to IndentFirstHashElement.
 Layout/IndentHash:
   EnforcedStyle: consistent
 


### PR DESCRIPTION
I'd like to propose that we change the IndentHash style from (default) "special_inside_parentheses" to "consistent".

```
# special_inside_parentheses
hash = {
  key: :value
}
but_in_a_method_call({
                       its_like: :this
                     })
```

```
# consistent
hash = {
  key: :value
}
and_in_a_method_call({
  no: :difference
})
```

See this link for full details: https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/IndentHash

I'll also note that in Rubocop 0.68 (a newer version than we're using right now), the IndentHash rule was renamed to IndentFirstHashElement, so if this PR is approved then we may want to create a GitHub issue (or other reminder) to update this rule in the future when we update rubocop.

See: https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutindentfirsthashelement