### PR TITLE
Enforcing single quotes when not interpolating

### DIFF
--- a/rubocul_default.yml
+++ b/rubocul_default.yml
@@ -11,3 +11,8 @@ Layout/IndentHash:
 
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining
+
+# Bixby does not have this cop turned on by default, though it is enabled in the default Rubocop config.
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: single_quotes


### PR DESCRIPTION
Bixby does not enabled this cop by default and I think it should be enabled. We can debate about what the enforced style should be, but either way I think we should have an opinion on this.

Here's some documentation on the cop: 
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StringLiterals