### PR TITLE
Ignoring Metrics/BlockLength for specs

### DIFF
--- a/rubocul_default.yml
+++ b/rubocul_default.yml
@@ -11,3 +11,7 @@ Layout/IndentHash:
 
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining
+  
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'


### PR DESCRIPTION
Sometimes the do/end block that encompasses the entire spec file gets long and often fails this cop. Generally, we want to encourage having more tests, not less and this can cop can sometimes get in the way.