### PR TITLE
Merging arrays of exclusion filepaths

### DIFF
--- a/rubocul_default.yml
+++ b/rubocul_default.yml
@@ -1,6 +1,15 @@
 inherit_gem:
   bixby: bixby_default.yml
 
+inherit_mode:
+  merge:
+    - Exclude
+    
+AllCops:
+  Exclude:
+    - 'app/javascript/**/*'
+    - 'node_modules/**/*'
+
 # Turning off until we can support multiple enforced styles (key and table). This is available in newer version of rubocop.
 Layout/AlignHash:
   Enabled: false


### PR DESCRIPTION
When inheriting cop configuration, arrays are usually overwritten and not merge. For the exclusion configuration in each cop, we want to merge the array in order to keep exclusions that have been configured in bixby, the configuration we inherit from.