### PR TITLE
Disable Rails/HasAndBelongsToMany

### DIFF
--- a/rubocul_default.yml
+++ b/rubocul_default.yml
@@ -11,3 +11,6 @@ Layout/IndentHash:
 
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining
+
+Rails/HasAndBelongsToMany:
+  Enabled: false


### PR DESCRIPTION
This cop forces us to convert HasAndBelongsToMany relationships to HasMany/Through. This makes us create the intermediary model, which in many cases we do not need.