### PR TITLE
Disable RSpec/MessageSpies

### DIFF
--- a/rubocul_default.yml
+++ b/rubocul_default.yml
@@ -9,5 +9,8 @@ Layout/AlignHash:
 Layout/IndentHash:
   EnforcedStyle: consistent
 
+RSpec/MessageSpies:
+  Enabled: false
+
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining


### PR DESCRIPTION
I don't mind if other people want to use the `have_received` message spy method, but I tend to prefer `receive` because it eliminates additional setup code and makes tests a bit more concise.  I'd like to propose that we disable the RSpec/MessageSpies rule so that developers are free to choose whichever method they prefer (and make testing easier for all in order to encourage more testing).

Cop info: https://rubocop-rspec.readthedocs.io/en/latest/cops_rspec/#rspecmessagespies